### PR TITLE
#23 on message attachment if original id cannot parse of X-Attachment-Id, it should fallback to attachment name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "skn036/laravel-gmail-api",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Wrapper around gmail api for laravel.",
     "keywords": [
         "Muhammad Sajedul Karim",

--- a/src/Message/GmailMessageAttachment.php
+++ b/src/Message/GmailMessageAttachment.php
@@ -94,7 +94,12 @@ class GmailMessageAttachment
     protected function resolveAttachmentFromPart($part)
     {
         $this->id = $part->getBody()->getAttachmentId();
+
+        // original id is important as the id changes on every request. original id should be same for the same attachment
         $this->originalId = $this->getHeaderValue('X-Attachment-Id', collect($part->getHeaders()));
+        if (!$this->originalId) {
+            $this->originalId = $part->getFilename();
+        }
         $this->filename = $part->getFilename();
         $this->mimeType = $part->getMimeType();
         $this->size = $part->getBody()->getSize();


### PR DESCRIPTION
#23